### PR TITLE
共有定義を「同意不要」で定義すると、蓄積イベント通知が送信されない問題の修正 issue/#10

### DIFF
--- a/config/message.json
+++ b/config/message.json
@@ -58,6 +58,7 @@
     "INVALID_APPROVAL_ACTOR": "承認アクターが対象のアクターではありません。",
     "INVALID_CANDIDATE_CODE": "紐づけられているカタログコードが不正です(コード: %s)",
     "NOT_IMPLEMENTED_SEARCHSERVICE": "検索サービスを実装する必要があります",
+    "INVALID_VERSION_RANGE": "取得起点バージョンに終点起点バージョンより大きい値が設定されています",
     "validation": {
         "isArray": "配列ではありません",
         "isBoolean": "真偽値ではありません",

--- a/config/openapi.json
+++ b/config/openapi.json
@@ -279,6 +279,62 @@
                 }
             }
         },
+        "/history/{code}": {
+            "get": {
+                "tags": [
+                    "取得"
+                ],
+                "description": "指定コードのカタログについて、指定された範囲のバージョンのカタログを取得する",
+                "parameters": [
+                    {
+                        "name": "code",
+                        "description": "取得対象カタログコード",
+                        "in": "path",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true,
+                        "example": 1
+                    },
+                    {
+                        "name": "min",
+                        "description": "取得起点カタログバージョン",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true,
+                        "example": 1
+                    },
+                    {
+                        "name": "max",
+                        "description": "取得終点カタログバージョン",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": false,
+                        "example": 1
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "カタログ履歴の取得に成功した際のレスポンスコード",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "description": "カタログ履歴取得のレスポンスボディ",
+                                    "items": {
+                                        "$ref": "#/components/schemas/catalogResponse"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/{code}": {
             "get": {
                 "tags": [

--- a/ddl/unit-test/initialCatalogHistoryCode.sql
+++ b/ddl/unit-test/initialCatalogHistoryCode.sql
@@ -1,0 +1,51 @@
+INSERT INTO pxr_catalog.catalog_item
+(
+    id, code, version, ns_id, name, description,
+    inherit_code, inherit_version, is_reserved, is_disabled,
+    response,
+    attributes,
+    created_by, created_at, updated_by, updated_at
+) VALUES
+(
+    101, 1000001, 1, 5, 'ユニットテスト', 'ユニットテスト用(ext)',
+    NULL, NULL, False, False,
+    '{ "catalogItem": { "ns": "catalog/ext/unit-test", "name": "ユニットテスト", "_code": { "_value": 1000001, "_ver": 1 }, "inherit": null, "description": null }, "template": { "_code": { "_value": 1000001, "_ver": 1 } }, "prop": null, "value": null, "attribute": null }',
+    NULL,
+    'catalog_registrant', '2021/11/10 11:30:01.087', 'catalog_registrant', '2021/11/10 11:30:01.087'
+),
+(
+    102, 1000001, 2, 5, 'ユニットテスト', 'ユニットテスト用(ext)',
+    NULL, NULL, False, False,
+    '{ "catalogItem": { "ns": "catalog/ext/unit-test", "name": "ユニットテスト", "_code": { "_value": 1000001, "_ver": 2 }, "inherit": null, "description": null }, "template": { "_code": { "_value": 1000001, "_ver": 2 } }, "prop": null, "value": null, "attribute": null }',
+    NULL,
+    'catalog_registrant', '2021/11/10 11:31:01.087', 'catalog_registrant', '2021/11/10 11:31:01.087'
+),
+(
+    103, 1000001, 3, 5, 'ユニットテスト', 'ユニットテスト用(ext,論理削除)',
+    NULL, NULL, False, true,
+    '{ "catalogItem": { "ns": "catalog/ext/unit-test", "name": "ユニットテスト", "_code": { "_value": 1000001, "_ver": 3 }, "inherit": null, "description": null }, "template": { "_code": { "_value": 1000001, "_ver": 3 } }, "prop": null, "value": null, "attribute": null }',
+    NULL,
+    'catalog_registrant', '2021/11/10 11:32:01.087', 'catalog_registrant', '2021/11/10 11:32:01.087'
+),
+(
+    104, 1000001, 4, 5, 'ユニットテスト', 'ユニットテスト用(ext)',
+    NULL, NULL, False, False,
+    '{ "catalogItem": { "ns": "catalog/ext/unit-test", "name": "ユニットテスト", "_code": { "_value": 1000001, "_ver": 4 }, "inherit": null, "description": null }, "template": { "_code": { "_value": 1000001, "_ver": 4 } }, "prop": null, "value": null, "attribute": null }',
+    NULL,
+    'catalog_registrant', '2021/11/10 11:32:01.087', 'catalog_registrant', '2021/11/10 11:32:01.087'
+),
+(
+    105, 1000001, 5, 5, 'ユニットテスト', 'ユニットテスト用(ext)',
+    NULL, NULL, False, False,
+    '{ "catalogItem": { "ns": "catalog/ext/unit-test", "name": "ユニットテスト", "_code": { "_value": 1000001, "_ver": 5 }, "inherit": null, "description": null }, "template": { "_code": { "_value": 1000001, "_ver": 5 } }, "prop": null, "value": null, "attribute": null }',
+    NULL,
+    'catalog_registrant', '2021/11/10 11:32:01.087', 'catalog_registrant', '2021/11/10 11:32:01.087'
+),
+(
+    106, 1000002, 1, 5, 'ユニットテスト', 'ユニットテスト用(ext)',
+    NULL, NULL, False, False,
+    '{ "catalogItem": { "ns": "catalog/ext/unit-test", "name": "ユニットテスト", "_code": { "_value": 1000002, "_ver": 1 }, "inherit": null, "description": null }, "template": { "_code": { "_value": 1000002, "_ver": 1 } }, "prop": null, "value": null, "attribute": null }',
+    NULL,
+    'catalog_registrant', '2021/11/10 11:30:01.087', 'catalog_registrant', '2021/11/10 11:30:01.087'
+)
+;

--- a/src/domains/CatalogItemDomain.ts
+++ b/src/domains/CatalogItemDomain.ts
@@ -47,6 +47,11 @@ export default class CatalogItemDomain {
     codeVersions: any[] = null;
 
     /**
+     * カタログバージョン範囲
+     */
+    versionRange: { min: number, max: number } = { min: null, max: null };
+
+    /**
      * ネームスペースID
      */
     nsId: number = null;

--- a/src/repositories/postgres/CatalogItemRepository.ts
+++ b/src/repositories/postgres/CatalogItemRepository.ts
@@ -85,6 +85,12 @@ export default class CatalogItemRepository {
                 sql = sql.andWhere(`(catalog_item.code, catalog_item.version) in (${conditionStr})`, params);
             }
         }
+        if (domain.versionRange.min) {
+            sql = sql.andWhere('catalog_item.version >= :min', { min: domain.versionRange.min });
+        }
+        if (domain.versionRange.max) {
+            sql = sql.andWhere('catalog_item.version <= :max', { max: domain.versionRange.max });
+        }
         sql = sql.orderBy('catalog_item.code', 'ASC')
             .addOrderBy('catalog_item.version', 'ASC');
 

--- a/src/resources/dto/CatalogGetHistoryCodeReqDto.ts
+++ b/src/resources/dto/CatalogGetHistoryCodeReqDto.ts
@@ -1,0 +1,45 @@
+/* eslint-disable */
+import {
+    IsDefined,
+    IsString,
+    IsUrl,
+    IsNumber,
+    IsInt,
+    ValidateNested,
+    IsDate,
+    IsBoolean,
+    IsNotEmpty,
+    IsOptional,
+    Min,
+    Max
+} from 'class-validator';
+import { Transform } from 'class-transformer';
+/* eslint-enable */
+
+/**
+ * GET: カタログ履歴取得のリクエストDTO
+ */
+export default class CatalogGetHistoryCodeReqDto {
+    @Min(1)
+    @Max(Number.MAX_SAFE_INTEGER)
+    @IsNumber()
+    @Transform(({ value }) => { return parseInt(value); })
+    @IsNotEmpty()
+    @IsDefined()
+        code: number = null;
+
+    @Min(1)
+    @Max(Number.MAX_SAFE_INTEGER)
+    @IsNumber()
+    @Transform(({ value }) => { return parseInt(value); })
+    @IsNotEmpty()
+    @IsDefined()
+        min: number = null;
+
+    @Min(1)
+    @Max(Number.MAX_SAFE_INTEGER)
+    @IsNumber()
+    @Transform(({ value }) => { return parseInt(value); })
+    @IsOptional()
+        max: number = null;
+}

--- a/src/resources/dto/CatalogGetHistoryCodeResDto.ts
+++ b/src/resources/dto/CatalogGetHistoryCodeResDto.ts
@@ -1,0 +1,32 @@
+/**
+ * GET: カタログ履歴取得のレスポンスDTO
+ */
+export class CodeObject {
+    _value: number = null;
+
+    _ver: number = null;
+}
+
+export class CatalogItem {
+    ns: string = null;
+
+    name: string = null;
+
+    _code: CodeObject = null;
+
+    inherit: CodeObject = null;
+
+    description: string = null;
+}
+
+export default class CatalogGetHistoryCodeResDto {
+    catalogItem: CatalogItem = null;
+
+    template: {} = null;
+
+    prop: {}[] | null = null;
+
+    value: {}[] | null = null;
+
+    attribute: {} | null = null;
+}

--- a/src/resources/validator/CatalogGetHistoryCodeValidator.ts
+++ b/src/resources/validator/CatalogGetHistoryCodeValidator.ts
@@ -1,0 +1,27 @@
+/* eslint-disable */
+import { Request, Response, NextFunction } from 'express';
+import { Middleware, ExpressMiddlewareInterface } from 'routing-controllers';
+/* eslint-enable */
+import { transformAndValidate } from 'class-transformer-validator';
+import CatalogGetHistoryCodeReqDto from '../dto/CatalogGetHistoryCodeReqDto';
+import AppError from '../../common/AppError';
+import { ResponseCode } from '../../common/ResponseCode';
+import Config from '../../common/Config';
+const message = Config.ReadConfig('./config/message.json');
+
+/**
+ * カタログ履歴取得APIのバリデーションチェッククラス
+ */
+@Middleware({ type: 'before' })
+export default class CatalogGetHistoryCodeValidator implements ExpressMiddlewareInterface {
+    async use (request: Request, response: Response, next: NextFunction) {
+        // パラメータを取得
+        const dto = await transformAndValidate(CatalogGetHistoryCodeReqDto, Object.assign(request.params, request.query));
+        if (dto.max && dto.min > dto.max) {
+            throw new AppError(message.INVALID_VERSION_RANGE, ResponseCode.BAD_REQUEST);
+        }
+        if (next) {
+            next();
+        }
+    }
+}

--- a/src/services/dto/CatalogServiceDto.ts
+++ b/src/services/dto/CatalogServiceDto.ts
@@ -69,6 +69,16 @@ export default class CatalogServiceDto {
     private catalog: {} = null;
 
     /**
+     * 取得起点カタログバージョン
+     */
+    private min: number = null;
+
+    /**
+     * 取得終点カタログバージョン
+     */
+    private max: number = null;
+
+    /**
      * カタログコードリスト
      */
     private codes: CatalogPostByCodesReqDto[] = null;
@@ -151,5 +161,21 @@ export default class CatalogServiceDto {
 
     public setCodes (codes: CatalogPostByCodesReqDto[]): void {
         this.codes = codes;
+    }
+
+    public getMin (): number {
+        return this.min;
+    }
+
+    public setMin (min: number): void {
+        this.min = min;
+    }
+
+    public getMax (): number {
+        return this.max;
+    }
+
+    public setMax (max: number): void {
+        this.max = max;
     }
 }

--- a/src/tests/10-01.CatalogHistoryCode.spec.ts
+++ b/src/tests/10-01.CatalogHistoryCode.spec.ts
@@ -1,0 +1,426 @@
+/* eslint-disable */
+import * as supertest from 'supertest';
+import { Application } from '../resources/config/Application';
+import Common, { Url } from './Common';
+import { Session } from './Session';
+import Config from '../common/Config';
+import { CatalogHistoryCodeResponse } from './CatalogHistoryCodeResponse';
+import urljoin = require('url-join');
+/* eslint-enable */
+const Message = Config.ReadConfig('./config/message.json');
+
+// 対象アプリケーションを取得
+const app = new Application();
+const expressApp = app.express.app;
+const common = new Common();
+
+// サーバをlisten
+app.start();
+
+/**
+ * catalog API のユニットテスト
+ */
+describe('catalog API', () => {
+    /**
+     * 全テスト実行前の処理
+     */
+    beforeAll(async () => {
+        // DB接続
+        await common.connect();
+        // DB初期化
+        await common.executeSqlFile('initialData.sql');
+        await common.executeSqlFile('activate.sql');
+        await common.executeSqlFile('catalogCodeScope.sql');
+        await common.executeSqlFile('nameSpace.sql');
+        await common.executeSqlFile('initialCatalogHistoryCode.sql');
+    });
+    /**
+     * 全テスト実行後の処理
+     */
+    afterAll(async () => {
+        // DB切断
+        // await common.disconnect();
+        // サーバ停止
+        app.stop();
+    });
+
+    /**
+     * カタログ履歴取得(/history/:code)
+     */
+    describe('カタログ履歴取得(/history/:code)', () => {
+        test('異常:codeが有効範囲外の数値(1より小さい)', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '0', '?min=1');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(400);
+            expect(response.body.reasons[0].property).toBe('code');
+            expect(response.body.reasons[0].message).toBe(Message.validation.min);
+        });
+        test('異常:codeが有効範囲外の数値(Number.MAX_SAFE_INTEGERより大きい)', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', (Number.MAX_SAFE_INTEGER + 1).toString(), '?min=1');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(400);
+            expect(response.body.reasons[0].property).toBe('code');
+            expect(response.body.reasons[0].message).toBe(Message.validation.max);
+        });
+        test('異常:minが未指定', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(400);
+            expect(response.body.reasons[0].message).toBe(Message.validation.isDefined);
+        });
+        test('異常:minが有効範囲外の数値(1より小さい)', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=0');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(400);
+            expect(response.body.reasons[0].property).toBe('min');
+            expect(response.body.reasons[0].message).toBe(Message.validation.min);
+        });
+        test('異常:minが有効範囲外の数値(Number.MAX_SAFE_INTEGERより大きい)', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=' + (Number.MAX_SAFE_INTEGER + 1).toString());
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(400);
+            expect(response.body.reasons[0].property).toBe('min');
+            expect(response.body.reasons[0].message).toBe(Message.validation.max);
+        });
+        test('異常:minが数値以外', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=test');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(400);
+            expect(response.body.reasons[0].property).toBe('min');
+            expect(response.body.reasons[0].message).toBe(Message.validation.isNumber);
+        });
+        test('異常:minが取得対象カタログの最新バージョンより大きい', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=100');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(404);
+            expect(response.body.message).toBe(Message.CATALOG_NOT_FOUND);
+        });
+        test('異常:maxが有効範囲外の数値(1より小さい)', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=1&max=0');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(400);
+            expect(response.body.reasons[0].property).toBe('max');
+            expect(response.body.reasons[0].message).toBe(Message.validation.min);
+        });
+        test('異常:maxが有効範囲外の数値(Number.MAX_SAFE_INTEGERより大きい)', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=1&max=' + (Number.MAX_SAFE_INTEGER + 1).toString());
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(400);
+            expect(response.body.reasons[0].property).toBe('max');
+            expect(response.body.reasons[0].message).toBe(Message.validation.max);
+        });
+        test('異常:maxが数値以外', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=1&max=test');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(400);
+            expect(response.body.reasons[0].property).toBe('max');
+            expect(response.body.reasons[0].message).toBe(Message.validation.isNumber);
+        });
+        test('異常:maxがminより大きい', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=2&max=1');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(400);
+            expect(response.body.message).toBe(Message.INVALID_VERSION_RANGE);
+        });
+        test('異常:カタログの存在しないcodeを指定', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '2000001', '?min=1');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(404);
+            expect(response.body.message).toBe(Message.CATALOG_NOT_FOUND);
+        });
+        test('正常:max未指定', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=1');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(200);
+            expect(response.body.length).toBe(4);
+            expect(response.body[0]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver1);
+            expect(JSON.stringify(response.body[0])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver1));
+            expect(response.body[1]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver2);
+            expect(JSON.stringify(response.body[1])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver2));
+            expect(response.body[2]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver4);
+            expect(JSON.stringify(response.body[2])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver4));
+            expect(response.body[3]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver5);
+            expect(JSON.stringify(response.body[3])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver5));
+        });
+        test('正常:max指定,maxが取得対象カタログの最新バージョンより小さい', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=2&max=4');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(200);
+            expect(response.body.length).toBe(2);
+            expect(response.body[0]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver2);
+            expect(JSON.stringify(response.body[0])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver2));
+            expect(response.body[1]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver4);
+            expect(JSON.stringify(response.body[1])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver4));
+        });
+        test('正常:max指定,maxが取得対象カタログの最新バージョンより大きい', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=1&max=100');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(200);
+            expect(response.body.length).toBe(4);
+            expect(response.body[0]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver1);
+            expect(JSON.stringify(response.body[0])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver1));
+            expect(response.body[1]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver2);
+            expect(JSON.stringify(response.body[1])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver2));
+            expect(response.body[2]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver4);
+            expect(JSON.stringify(response.body[2])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver4));
+            expect(response.body[3]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver5);
+            expect(JSON.stringify(response.body[3])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver5));
+        });
+        test('正常:min=max指定', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=2&max=2');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(200);
+            expect(response.body.length).toBe(1);
+            expect(response.body[0]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver2);
+            expect(JSON.stringify(response.body[0])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver2));
+        });
+        test('異常:min=max指定(論理削除されたバージョンのみの指定)', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=3&max=3');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(404);
+            expect(response.body.message).toBe(Message.CATALOG_NOT_FOUND);
+        });
+        test('正常:min=max指定(最小バージョンのみの指定)', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=1&max=1');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(200);
+            expect(response.body.length).toBe(1);
+            expect(response.body[0]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver1);
+            expect(JSON.stringify(response.body[0])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver1));
+        });
+        test('正常:min=max指定(最大バージョンのみの指定)', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=5&max=5');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(200);
+            expect(response.body.length).toBe(1);
+            expect(response.body[0]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver5);
+            expect(JSON.stringify(response.body[0])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver5));
+        });
+        test('正常:minが論理削除されたカタログのバージョン', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=3&max=5');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(200);
+            expect(response.body.length).toBe(2);
+            expect(response.body[0]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver4);
+            expect(JSON.stringify(response.body[0])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver4));
+            expect(response.body[1]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver5);
+            expect(JSON.stringify(response.body[1])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver5));
+        });
+        test('正常:maxが論理削除されたカタログのバージョン', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000001', '?min=1&max=3');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(200);
+            expect(response.body.length).toBe(2);
+            expect(response.body[0]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver1);
+            expect(JSON.stringify(response.body[0])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver1));
+            expect(response.body[1]).toMatchObject(CatalogHistoryCodeResponse.ext1000001ver2);
+            expect(JSON.stringify(response.body[1])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000001ver2));
+        });
+        test('正常:最新バージョンが1のカタログの取得', async () => {
+            // URLを生成
+            const url = urljoin(Url.baseURI, 'history', '1000002', '?min=1');
+
+            // 対象APIに送信
+            const response = await supertest(expressApp)
+                .get(url)
+                .set({ accept: 'application/json' })
+                .set({ session: JSON.stringify(Session.pxrRoot) })
+                .send();
+
+            // レスポンスチェック
+            expect(response.status).toBe(200);
+            expect(response.body.length).toBe(1);
+            expect(response.body[0]).toMatchObject(CatalogHistoryCodeResponse.ext1000002ver1);
+            expect(JSON.stringify(response.body[0])).toBe(JSON.stringify(CatalogHistoryCodeResponse.ext1000002ver1));
+        });
+    });
+});

--- a/src/tests/CatalogHistoryCodeResponse.ts
+++ b/src/tests/CatalogHistoryCodeResponse.ts
@@ -1,0 +1,154 @@
+/**
+ * カタログレスポンス(拡張)
+ */
+export namespace CatalogHistoryCodeResponse {
+    /**
+     * null設定オブジェクト
+     */
+    const NULL: any = null;
+
+    /**
+    * 最小限カタログ(code:1000001,ver:1)
+    */
+    export const ext1000001ver1 = {
+        catalogItem: {
+            ns: 'catalog/ext/unit-test',
+            name: 'ユニットテスト',
+            _code: {
+                _value: 1000001,
+                _ver: 1
+            },
+            inherit: NULL,
+            description: NULL
+        },
+        template: {
+            _code: {
+                _value: 1000001,
+                _ver: 1
+            }
+        },
+        prop: NULL,
+        value: NULL,
+        attribute: NULL
+    };
+    /**
+    * 最小限カタログ(code:1000001,ver:2)
+    */
+    export const ext1000001ver2 = {
+        catalogItem: {
+            ns: 'catalog/ext/unit-test',
+            name: 'ユニットテスト',
+            _code: {
+                _value: 1000001,
+                _ver: 2
+            },
+            inherit: NULL,
+            description: NULL
+        },
+        template: {
+            _code: {
+                _value: 1000001,
+                _ver: 2
+            }
+        },
+        prop: NULL,
+        value: NULL,
+        attribute: NULL
+    };
+    /**
+    * 最小限カタログ(code:1000001,ver:3)
+    */
+    export const ext1000001ver3 = {
+        catalogItem: {
+            ns: 'catalog/ext/unit-test',
+            name: 'ユニットテスト',
+            _code: {
+                _value: 1000001,
+                _ver: 3
+            },
+            inherit: NULL,
+            description: NULL
+        },
+        template: {
+            _code: {
+                _value: 1000001,
+                _ver: 3
+            }
+        },
+        prop: NULL,
+        value: NULL,
+        attribute: NULL
+    };
+    /**
+    * 最小限カタログ(code:1000001,ver:4)
+    */
+    export const ext1000001ver4 = {
+        catalogItem: {
+            ns: 'catalog/ext/unit-test',
+            name: 'ユニットテスト',
+            _code: {
+                _value: 1000001,
+                _ver: 4
+            },
+            inherit: NULL,
+            description: NULL
+        },
+        template: {
+            _code: {
+                _value: 1000001,
+                _ver: 4
+            }
+        },
+        prop: NULL,
+        value: NULL,
+        attribute: NULL
+    };
+    /**
+    * 最小限カタログ(code:1000001,ver:3)
+    */
+    export const ext1000001ver5 = {
+        catalogItem: {
+            ns: 'catalog/ext/unit-test',
+            name: 'ユニットテスト',
+            _code: {
+                _value: 1000001,
+                _ver: 5
+            },
+            inherit: NULL,
+            description: NULL
+        },
+        template: {
+            _code: {
+                _value: 1000001,
+                _ver: 5
+            }
+        },
+        prop: NULL,
+        value: NULL,
+        attribute: NULL
+    };
+    /**
+    * 最小限カタログ(code:1000002,ver:1)
+    */
+    export const ext1000002ver1 = {
+        catalogItem: {
+            ns: 'catalog/ext/unit-test',
+            name: 'ユニットテスト',
+            _code: {
+                _value: 1000002,
+                _ver: 1
+            },
+            inherit: NULL,
+            description: NULL
+        },
+        template: {
+            _code: {
+                _value: 1000002,
+                _ver: 1
+            }
+        },
+        prop: NULL,
+        value: NULL,
+        attribute: NULL
+    };
+}


### PR DESCRIPTION
## 修正内容

### カタログサービス.カタログ履歴取得API（新規API）
- 概要
    - 指定コードのカタログについて、指定バージョンから最新まで全てのバージョンを取得する

- 利用ケース
    - book-manageサービスからデータ操作定義カタログの履歴を取得時に使用
    - 将来的にUIから呼び出されることを想定し、ログイン済の全てのオペレータ種からの呼出を許可する

- 静的認可
    - 運営メンバー, アプリケーション, 個人
- メソッド・パス
    - GET /catalog/history/:code

- パスパラメータ
    - code: 取得対象カタログコード

- クエリパラメータ
    - min: 取得起点カタログバージョン
    - max: 取得終点カタログバージョン（optional）

- 処理内容
    - 対象カタログの最新バージョンを取得し、query.max が未指定あるいは最新より大きい場合、最新バージョンを終点に設定する
    - カタログ情報取得メソッド（CatalogService.getCatalogInfo() ）の引数にmin, maxをそれぞれ設定して呼び出す
    - 各バージョンの取得結果をレスポンス配列に格納して返却する

    - カタログ情報取得で使用するCatalogItemDomainにプロパティ追加
        - versionRange: object型
            - min: number型
            - max: number型
    - CatalogService.getCatalogInfo() を修正
        - 引数にmin, maxを追加（optional, デフォルトはnull）
        - DBからカタログ情報取得する際、catalogItemDomainにversionRange設定を追加
            - 引数のmin, max がnullの場合はnullを設定
    - DBからカタログ情報を取得するメソッド（CatalogItemRepository.getRecord() ）のSQLを変更
        - domain.versionRange.min がnullでない場合
            - version >= min の条件を追加
        - domain.versionRange.max がnullでない場合
            - version <= max の条件を追加

- 返却値
    - カタログ項目配列

fixes #10 

## UnitTest
### UT環境
```
$ node --version
v18.16.1
```
```
$ psql -V
psql (PostgreSQL) 15.6
```

### UT実行結果
```
$ npm run test:unit

> catalog-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

PASS src/tests/04-01.Catalog.model.spec.ts (54.639 s)
PASS src/tests/04-02.Catalog.built_in.spec.ts (21.616 s)
PASS src/tests/04-03.Catalog.ext.spec.ts (20.759 s)
PASS src/tests/07-01.UpdateSet.spec.ts (9.292 s)
PASS src/tests/07-02.UpdateSet.spec.ts (6.375 s)
PASS src/tests/01-01.NameSpace.spec.ts (8.142 s)
PASS src/tests/02-01.CatalogCodeScope.spec.ts (8.372 s)
PASS src/tests/04-04.Catalog.model.error.spec.ts (8.522 s)
PASS src/tests/09-01.Attribute.spec.ts (5.84 s)
PASS src/tests/03-01.CatalogName.spec.ts (5.146 s)
PASS src/tests/06-01.CatalogFullText.spec.ts
PASS src/tests/05-01.CatalogInner.spec.ts (6.925 s)
PASS src/tests/10-01.CatalogHistoryCode.spec.ts (5.199 s)
PASS src/tests/04-07.Catalog.dbError.spec.ts
PASS src/tests/04-08.Catalog.dbError.spec.ts
PASS src/tests/01-02.NameSpace.dbError.spec.ts (5.148 s)
PASS src/tests/04-05.Catalog.dbError.spec.ts
PASS src/tests/02-02.CatalogCodeScope.dbError.spec.ts
PASS src/tests/02-03.CatalogCodeScope.dbError.spec.ts
PASS src/tests/07-03.UpdateSet.dbError.spec.ts
PASS src/tests/07-04.UpdateSet.dbError.spec.ts
PASS src/tests/04-06.Catalog.dbError.spec.ts
PASS src/tests/03-02.CatalogName.dbError.spec.ts
PASS src/tests/08-01.CatalogPublic.spec.ts
PASS src/tests/03-03.CatalogName.dbError.spec.ts
PASS src/tests/04-09.Catalog.bulk.spec.ts (51.288 s)
PASS src/tests/03-04.CatalogName.dbError.spec.ts
--------------------------------|---------|----------|---------|---------|------------------------------
File                            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s       
--------------------------------|---------|----------|---------|---------|------------------------------
All files                       |   98.16 |     97.5 |   97.97 |   98.21 |                         
 resources                      |     100 |      100 |     100 |     100 |                         
  AttributeController.ts        |     100 |      100 |     100 |     100 |                         
  CatalogCodeScopeController.ts |     100 |      100 |     100 |     100 |                         
  CatalogController.ts          |     100 |      100 |     100 |     100 |                         
  CatalogFullTextController.ts  |     100 |      100 |     100 |     100 |                         
  CatalogNameController.ts      |     100 |      100 |     100 |     100 |                         
  NameSpaceController.ts        |     100 |      100 |     100 |     100 |                         
  UpdateSetController.ts        |     100 |      100 |     100 |     100 |                         
 services                       |    97.8 |    97.47 |   97.51 |   97.86 |                         
  AttributeService.ts           |     100 |      100 |     100 |     100 |                         
  CatalogCodeScopeService.ts    |     100 |      100 |     100 |     100 |                         
  CatalogFullTextService.ts     |   66.36 |    70.27 |   71.42 |    67.3 | 65-73,92,106,124-138,190-204
  CatalogNameService.ts         |   98.75 |      100 |   88.88 |   98.71 | 110                     
  CatalogService.ts             |   99.09 |    99.13 |   98.66 |   99.08 | 512-523,703             
  NameSpaceService.ts           |     100 |      100 |     100 |     100 |                         
  OperatorService.ts            |     100 |      100 |     100 |     100 |                         
  UpdateSetService.ts           |   98.93 |    97.89 |     100 |    98.9 | 414-423                 
--------------------------------|---------|----------|---------|---------|------------------------------

Test Suites: 27 passed, 27 total
Tests:       1780 passed, 1780 total
Snapshots:   0 total
Time:        277.003 s
Ran all test suites.
```